### PR TITLE
Loading YAML configuration should default to an empty hash

### DIFF
--- a/lib/dossier/configuration.rb
+++ b/lib/dossier/configuration.rb
@@ -17,6 +17,8 @@ module Dossier
 
     def yaml_config
       YAML.load(ERB.new(File.read(@config_path)).result)[Rails.env].symbolize_keys
+    rescue
+      {}
     end
    
     def dburl_config


### PR DESCRIPTION
On Heroku, running`#yaml_config` raises an exception, as it attempts to call `#symbolize_keys` on nil. In general, any attempt to load the YAML configuration that fails should return an empty configuration.
